### PR TITLE
MbTilesProvider modificated

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	 <MajorVersion>0</MajorVersion>
 	 <MinorVersion>3</MinorVersion>
-	 <PatchVersion>1</PatchVersion> 
+	 <PatchVersion>2</PatchVersion> 
 	  	 
 	 <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	 <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/OgcApi.MbTiles.Tests/MbTilesFacts.cs
+++ b/OgcApi.MbTiles.Tests/MbTilesFacts.cs
@@ -5,6 +5,7 @@ using OgcApi.Net.MbTiles;
 using OgcApi.Net.Options;
 using System;
 using System.Collections.Generic;
+using OgcApi.Net.Options.Tiles;
 using Xunit;
 
 namespace OgcApi.MbTiles.Tests
@@ -28,7 +29,7 @@ namespace OgcApi.MbTiles.Tests
                     {
                         Title = "test",
                         Id =  "test",
-                        Tiles = new()
+                        Tiles = new CollectionTilesOptions
                         {
                             Crs = new Uri("http://www.opengis.net/def/crs/EPSG/0/3857"),
                             Storage = new MbTilesSourceOptions()

--- a/OgcApi.MbTiles.Tests/TestProviders.cs
+++ b/OgcApi.MbTiles.Tests/TestProviders.cs
@@ -4,6 +4,7 @@ using OgcApi.Net.Options;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using OgcApi.Net.Options.Tiles;
 
 namespace OgcApi.MbTiles.Tests
 {
@@ -19,14 +20,14 @@ namespace OgcApi.MbTiles.Tests
                     {
                         Title = "data",
                         Id =  "data",
-                        Tiles = new()
+                        Tiles = new CollectionTilesOptions
                         {
                             TileMatrixSet = new Uri("http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldMercatorWGS84Quad"),
                             Crs = new Uri("http://www.opengis.net/def/crs/EPSG/0/3395"),
                             Storage = new MbTilesSourceOptions()
                             {
                                 Type = "MbTiles",
-                                ConnectionString = "Data Source=" + Path.Combine("Data", "data.mbtiles")
+                                FileName = Path.Combine("Data", "data.mbtiles")
                             }
                         }
                     }
@@ -44,14 +45,14 @@ namespace OgcApi.MbTiles.Tests
                     {
                         Title = "data",
                         Id =  "data",
-                        Tiles = new()
+                        Tiles = new CollectionTilesOptions
                         {
                             TileMatrixSet = new Uri("http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldMercatorWGS84Quad"),
                             Crs = new Uri("http://www.opengis.net/def/crs/EPSG/0/3395"),
                             Storage = new MbTilesSourceOptions()
                             {
                                 Type = "MbTiles",
-                                ConnectionString = "Data Source=" + Path.Combine("Data", "test.mbtiles")
+                                FileName = "Data Source=" + Path.Combine("Data", "test.mbtiles")
                             }
                         }
                     }

--- a/OgcApi.Net.MbTiles/MbTilesProvider.cs
+++ b/OgcApi.Net.MbTiles/MbTilesProvider.cs
@@ -15,23 +15,21 @@ namespace OgcApi.Net.MbTiles
     {
         public string SourceType => "MbTiles";
 
-        ICollectionsOptions ITilesProvider.CollectionsOptions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public ICollectionsOptions CollectionsOptions { get; set; }
 
-        public ICollectionsOptions CollectionsOptions;
+        private readonly ILogger<MbTilesProvider> _logger;
 
-        protected readonly ILogger Logger;
-
-        public MbTilesProvider(ILogger logger)
+        public MbTilesProvider(ILogger<MbTilesProvider> logger)
         {
-            Logger = logger;
+            _logger = logger;
         }
 
-        private SqliteConnection GetDbConnection(string connectionString)
+        private static SqliteConnection GetDbConnection(string fileName)
         {
-            return new SqliteConnection(connectionString);
+            return new SqliteConnection($"Data Source={fileName}");
         }
 
-        private SqliteCommand GetDbCommand(string commandText, SqliteConnection dbConnection)
+        private static SqliteCommand GetDbCommand(string commandText, SqliteConnection dbConnection)
         {
             var command = dbConnection.CreateCommand();
             command.CommandText = commandText;
@@ -43,14 +41,14 @@ namespace OgcApi.Net.MbTiles
             var tileOptions = (MbTilesSourceOptions)CollectionsOptions.GetSourceById(collectionId)?.Tiles?.Storage;
             if (tileOptions == null)
             {
-                Logger.LogTrace(
+                _logger.LogTrace(
                     $"The tile source for collection with ID = {collectionId} was not found in the provided options");
                 throw new ArgumentException($"The tile source for collection with ID = {collectionId} does not exists");
             }
 
             try
             {
-                using var connection = GetDbConnection(tileOptions.ConnectionString);
+                using var connection = GetDbConnection(tileOptions.FileName);
                 connection.Open();
 
                 var command = GetDbCommand(@"SELECT zoom_level, MIN(tile_column), MAX(tile_column), MIN((1 << zoom_level) - 1 - tile_row), MAX((1 << zoom_level) - 1 - tile_row) FROM tiles GROUP BY zoom_level ORDER BY zoom_level", connection);
@@ -66,7 +64,7 @@ namespace OgcApi.Net.MbTiles
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "GetLimits database query completed with an exception");
+                _logger.LogError(ex, "GetLimits database query completed with an exception");
                 throw;
             }
         }
@@ -76,14 +74,14 @@ namespace OgcApi.Net.MbTiles
             var tileOptions = (MbTilesSourceOptions)CollectionsOptions.GetSourceById(collectionId)?.Tiles?.Storage;
             if (tileOptions == null)
             {
-                Logger.LogTrace(
+                _logger.LogTrace(
                     $"The tile source for collection with ID = {collectionId} was not found in the provided options");
                 throw new ArgumentException($"The tile source for collection with ID = {collectionId} does not exists");
             }
 
             try
             {
-                await using var connection = GetDbConnection(tileOptions.ConnectionString);
+                await using var connection = GetDbConnection(tileOptions.FileName);
                 connection.Open();
 
                 var command = GetDbCommand(@"SELECT tile_data FROM tiles WHERE zoom_level = $zoom_level AND tile_column = $tile_column AND tile_row = $tile_row", connection);
@@ -95,7 +93,7 @@ namespace OgcApi.Net.MbTiles
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "GetTileAsync database query completed with an exception");
+                _logger.LogError(ex, "GetTileAsync database query completed with an exception");
                 throw;
             }
         }

--- a/OgcApi.Net.MbTiles/MbTilesProviderServiceCollectionExtensions.cs
+++ b/OgcApi.Net.MbTiles/MbTilesProviderServiceCollectionExtensions.cs
@@ -1,13 +1,13 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using OgcApi.Net.DataProviders;
 
-namespace OgcApi.Net.PostGis
+namespace OgcApi.Net.MbTiles
 {
-    public static class OgcApiServiceCollectionExtensions
+    public static class MbTilesProviderServiceCollectionExtensions
     {
         public static IServiceCollection AddOgcApiPostGisProvider(this IServiceCollection services)
         {
-            services.AddSingleton<IFeaturesProvider, PostGisProvider>();
+            services.AddSingleton<ITilesProvider, MbTilesProvider>();
 
             return services;
         }

--- a/OgcApi.Net.MbTiles/MbTilesSourceOptions.cs
+++ b/OgcApi.Net.MbTiles/MbTilesSourceOptions.cs
@@ -7,7 +7,7 @@ namespace OgcApi.Net.MbTiles
     {
         public string Type { get; set; }
 
-        public string ConnectionString { set; get; }
+        public string FileName { set; get; }
 
         public List<string> Validate()
         {
@@ -16,8 +16,8 @@ namespace OgcApi.Net.MbTiles
             if (!Type.Equals("MbTiles"))
                 failureMessages.Add("Parameter Type requires \"MbTiles\" value for the \"MbTiles\" tile source option");
 
-            if (string.IsNullOrWhiteSpace(ConnectionString))
-                failureMessages.Add("Parameter ConnectionString is required for the \"MbTiles\" tile source option");
+            if (string.IsNullOrWhiteSpace(FileName))
+                failureMessages.Add("Parameter FileName is required for the \"MbTiles\" tile source option");
 
             return failureMessages;
         }

--- a/OgcApi.Net/Controllers/ConformanceController.cs
+++ b/OgcApi.Net/Controllers/ConformanceController.cs
@@ -52,17 +52,17 @@ namespace OgcApi.Net.Controllers
 
                 if (_apiOptions.Collections.Items.Any(item => item.Features != null))
                 {
-                    conformsTo.Add(new("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core"));
-                    conformsTo.Add(new("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30"));
-                    conformsTo.Add(new("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html"));
-                    conformsTo.Add(new("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"));
-                    conformsTo.Add(new("http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs"));
+                    conformsTo.Add(new Uri("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core"));
+                    conformsTo.Add(new Uri("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30"));
+                    conformsTo.Add(new Uri("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html"));
+                    conformsTo.Add(new Uri("http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"));
+                    conformsTo.Add(new Uri("http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs"));
                 }
 
                 if (_apiOptions.Collections.Items.Any(item => item.Tiles != null))
                 {
-                    conformsTo.Add(new("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset"));
-                    conformsTo.Add(new("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list"));
+                    conformsTo.Add(new Uri("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset"));
+                    conformsTo.Add(new Uri("http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list"));
                 }
 
 

--- a/OgcApi.Net/OpenApi/OpenApiGenerator.cs
+++ b/OgcApi.Net/OpenApi/OpenApiGenerator.cs
@@ -607,7 +607,7 @@ namespace OgcApi.Net.OpenApi
                                         {
                                             ["application/vnd.mapbox-vector-tile"] = new()
                                             {
-                                                Schema = new()
+                                                Schema = new OpenApiSchema
                                                 {
                                                     Type = "file"
                                                 }

--- a/OgcApi.Net/Options/Converters/OgcApiOptionsConverter.cs
+++ b/OgcApi.Net/Options/Converters/OgcApiOptionsConverter.cs
@@ -90,30 +90,30 @@ namespace OgcApi.Net.Options.Converters
                             landingPage.ContactName = reader.GetString();
                             break;
                         case "ContactUrl":
-                            landingPage.ContactUrl = new(reader.GetString());
+                            landingPage.ContactUrl = new Uri(reader.GetString());
                             break;
                         case "ApiDocumentPage":
-                            landingPage.ApiDocumentPage = new(reader.GetString());
+                            landingPage.ApiDocumentPage = new Uri(reader.GetString());
                             break;
                         case "Version":
-                            landingPage.Version = new(reader.GetString());
+                            landingPage.Version = new string(reader.GetString());
                             break;
                         case "ApiDescriptionPage":
-                            landingPage.ApiDescriptionPage = new(reader.GetString());
+                            landingPage.ApiDescriptionPage = new Uri(reader.GetString());
                             break;
                         case "LicenseName":
                             landingPage.LicenseName = reader.GetString();
                             break;
                         case "LicenseUrl":
-                            landingPage.LicenseUrl = new(reader.GetString());
+                            landingPage.LicenseUrl = new Uri(reader.GetString());
                             break;
                         case "Links":
-                            landingPage.Links = new();
+                            landingPage.Links = new List<Link>();
                             reader.Read();
                             while (reader.TokenType != JsonTokenType.EndArray)
                             {
                                 if (reader.TokenType == JsonTokenType.String)
-                                    landingPage.Links.Add(new() { Href = new(reader.GetString()) });
+                                    landingPage.Links.Add(new Link { Href = new Uri(reader.GetString()) });
                                 reader.Read();
                             }
                             break;

--- a/OgcApi.Net/Options/Tiles/CollectionTilesOptions.cs
+++ b/OgcApi.Net/Options/Tiles/CollectionTilesOptions.cs
@@ -6,7 +6,7 @@ namespace OgcApi.Net.Options.Tiles
     {
         public Uri Crs { get; set; }
 
-        public Uri TileMatrixSet { get; set; } = new Uri("http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad");
+        public Uri TileMatrixSet { get; set; } = new("http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad");
 
         public ITilesSourceOptions Storage { get; set; }
     }

--- a/OgcApi.Options.Tests/Utils/OptionsUtils.cs
+++ b/OgcApi.Options.Tests/Utils/OptionsUtils.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using OgcApi.Net.DataProviders;
-using OgcApi.Net.Features.PostGis;
 using OgcApi.Net.Options;
 using OgcApi.Net.Options.Converters;
 using OgcApi.Net.Options.Features;
@@ -11,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using OgcApi.Net.PostGis;
 
 namespace OgcApi.Options.Tests.Utils
 {
@@ -197,7 +197,7 @@ namespace OgcApi.Options.Tests.Utils
             var ms = new MemoryStream();
             var writer = new Utf8JsonWriter(ms);
             var converter = new OgcApiOptionsConverter(Provider);
-            converter.WriteCollections(writer, options, new());
+            converter.WriteCollections(writer, options, new JsonSerializerOptions());
             writer.Flush();
             ms.Close();
             return Encoding.UTF8.GetString(ms.ToArray());


### PR DESCRIPTION
Enchancements:
- Added MbTilesProviderServiceCollectionExtensions class to the OgcApi.Net.MbTiles project to simplify provider registration in ServiceCollection.
- MbTiles provider now depends on Logger<MbTilesProvider>
- MbTiles provider configuration options now include FileName instead of ConnectionString