### PR TITLE
Tile matrix limits calculation modified

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	 <MajorVersion>0</MajorVersion>
 	 <MinorVersion>3</MinorVersion>
-	 <PatchVersion>8</PatchVersion> 
+	 <PatchVersion>9</PatchVersion> 
 	  	 
 	 <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	 <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/OgcApi.Net.MbTiles/CoordinateConverter.cs
+++ b/OgcApi.Net.MbTiles/CoordinateConverter.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OgcApi.Net.MbTiles
 {
@@ -30,7 +26,7 @@ namespace OgcApi.Net.MbTiles
 
         public static double TileYToLat(int y, int z)
         {
-            double n = Math.PI - 2.0 * Math.PI * y / (double)(1 << z);
+            var n = Math.PI - 2.0 * Math.PI * y / (1 << z);
             return 180.0 / Math.PI * Math.Atan(0.5 * (Math.Exp(n) - Math.Exp(-n)));
         }
     }

--- a/OgcApi.Net.MbTiles/CoordinateConverter.cs
+++ b/OgcApi.Net.MbTiles/CoordinateConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OgcApi.Net.MbTiles
+{
+    public static class CoordinateConverter
+    {
+        private static double DegToRad(double deg)
+        {
+            return deg * Math.PI / 180;
+        }
+
+        public static int LongToTileX(double lon, int z)
+        {
+            return (int)(Math.Floor((lon + 180.0) / 360.0 * (1 << z)));
+        }
+
+        public static int LatToTileY(double lat, int z)
+        {
+            return (int)Math.Floor((1 - Math.Log(Math.Tan(DegToRad(lat)) + 1 / Math.Cos(DegToRad(lat))) / Math.PI) / 2 * (1 << z));
+        }
+
+        public static double TileXToLong(int x, int z)
+        {
+            return x / (double)(1 << z) * 360.0 - 180;
+        }
+
+        public static double TileYToLat(int y, int z)
+        {
+            double n = Math.PI - 2.0 * Math.PI * y / (double)(1 << z);
+            return 180.0 / Math.PI * Math.Atan(0.5 * (Math.Exp(n) - Math.Exp(-n)));
+        }
+    }
+}

--- a/OgcApi.Net.MbTiles/MbTilesProvider.cs
+++ b/OgcApi.Net.MbTiles/MbTilesProvider.cs
@@ -57,10 +57,10 @@ namespace OgcApi.Net.MbTiles
                 var getParamCommand = GetDbCommand(@"SELECT Value FROM metadata WHERE name = $name", connection);
 
                 getParamCommand.Parameters.AddWithValue("$name", "minzoom");
-                if (!int.TryParse(getParamCommand.ExecuteScalar()?.ToString(), out int minZoom)) return null;
+                if (!int.TryParse(getParamCommand.ExecuteScalar()?.ToString(), out var minZoom)) return null;
 
                 getParamCommand.Parameters["$name"].Value = "maxzoom";
-                if (!int.TryParse(getParamCommand.ExecuteScalar()?.ToString(), out int maxZoom)) return null;
+                if (!int.TryParse(getParamCommand.ExecuteScalar()?.ToString(), out var maxZoom)) return null;
 
                 getParamCommand.Parameters["$name"].Value = "bounds";
                 var boundsStr = getParamCommand.ExecuteScalar()?.ToString();
@@ -75,18 +75,13 @@ namespace OgcApi.Net.MbTiles
                 List<TileMatrixLimits> result = new();
                 for (int i = minZoom; i <= maxZoom; i++)
                 {
-                    var x1 = CoordinateConverter.LongToTileX(lon1, i);
-                    var y1 = CoordinateConverter.LatToTileY(lat1, i);
-                    var x2 = CoordinateConverter.LongToTileX(lon2, i);
-                    var y2 = CoordinateConverter.LatToTileY(lat2, i);
-
                     result.Add(new TileMatrixLimits
                     {
                         TileMatrix = i,
-                        MinTileCol = x1,
-                        MaxTileCol = x2,
-                        MinTileRow = y2,
-                        MaxTileRow = y1
+                        MinTileCol = CoordinateConverter.LongToTileX(lon1, i),
+                        MaxTileCol = CoordinateConverter.LongToTileX(lon2, i),
+                        MinTileRow = CoordinateConverter.LatToTileY(lat2, i),
+                        MaxTileRow = CoordinateConverter.LatToTileY(lat1, i)
                     });
                 }
                 return result;

--- a/OgcApi.Net.MbTiles/MbTilesProvider.cs
+++ b/OgcApi.Net.MbTiles/MbTilesProvider.cs
@@ -53,17 +53,17 @@ namespace OgcApi.Net.MbTiles
 
                 var checkMetadataCommand = GetDbCommand(@"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'metadata'", connection);
                 if (checkMetadataCommand.ExecuteScalar() == null) return null;
-                
+
                 var getParamCommand = GetDbCommand(@"SELECT Value FROM metadata WHERE name = $name", connection);
-                    
+
                 getParamCommand.Parameters.AddWithValue("$name", "minzoom");
-                if (!int.TryParse(getParamCommand.ExecuteScalar().ToString(), out int minZoom)) return null;
+                if (!int.TryParse(getParamCommand.ExecuteScalar()?.ToString(), out int minZoom)) return null;
 
                 getParamCommand.Parameters["$name"].Value = "maxzoom";
-                if (!int.TryParse(getParamCommand.ExecuteScalar().ToString(), out int maxZoom)) return null;
+                if (!int.TryParse(getParamCommand.ExecuteScalar()?.ToString(), out int maxZoom)) return null;
 
                 getParamCommand.Parameters["$name"].Value = "bounds";
-                var boundsStr = getParamCommand.ExecuteScalar().ToString();
+                var boundsStr = getParamCommand.ExecuteScalar()?.ToString();
                 if (boundsStr == null) return null;
                 string[] coordStrs = boundsStr.Split(',');
                 if (coordStrs.Length != 4) return null;

--- a/OgcApi.Net.MbTiles/MbTilesProvider.cs
+++ b/OgcApi.Net.MbTiles/MbTilesProvider.cs
@@ -65,12 +65,12 @@ namespace OgcApi.Net.MbTiles
                 getParamCommand.Parameters["$name"].Value = "bounds";
                 var boundsStr = getParamCommand.ExecuteScalar()?.ToString();
                 if (boundsStr == null) return null;
-                string[] coordStrs = boundsStr.Split(',');
+                var coordStrs = boundsStr.Split(',');
                 if (coordStrs.Length != 4) return null;
-                if (!double.TryParse(coordStrs[0], out double lon1)) return null;
-                if (!double.TryParse(coordStrs[1], out double lat1)) return null;
-                if (!double.TryParse(coordStrs[2], out double lon2)) return null;
-                if (!double.TryParse(coordStrs[3], out double lat2)) return null;
+                if (!double.TryParse(coordStrs[0], out var lon1)) return null;
+                if (!double.TryParse(coordStrs[1], out var lat1)) return null;
+                if (!double.TryParse(coordStrs[2], out var lon2)) return null;
+                if (!double.TryParse(coordStrs[3], out var lat2)) return null;
 
                 List<TileMatrixLimits> result = new();
                 for (int i = minZoom; i <= maxZoom; i++)


### PR DESCRIPTION
Tile matrix limits calculation based on grouping tiles data replaced with calculation from bbox, minzoom, maxzoom obtained from "metadata" table.