### PR TITLE
Fixed numberMatched when using feature attribute filters

### DIFF
--- a/OgcApi.Net/Controllers/CollectionsController.cs
+++ b/OgcApi.Net/Controllers/CollectionsController.cs
@@ -326,7 +326,8 @@ public class CollectionsController : ControllerBase
                     envelope,
                     dateTimeInterval.Start,
                     dateTimeInterval.End,
-                    apiKey);
+                    apiKey,
+                    propertyFilter);
 
                 if (offset + limit < features.TotalMatched)
                 {

--- a/OgcApi.Net/DataProviders/IFeaturesProvider.cs
+++ b/OgcApi.Net/DataProviders/IFeaturesProvider.cs
@@ -14,7 +14,7 @@ public interface IFeaturesProvider
 
     OgcFeature GetFeature(string collectionId, string featureId, string apiKey = null);
 
-    long GetFeaturesCount(string collectionId, Envelope bbox = null, DateTime? startDateTime = null, DateTime? endDateTime = null, string apiKey = null);
+    long GetFeaturesCount(string collectionId, Envelope bbox = null, DateTime? startDateTime = null, DateTime? endDateTime = null, string apiKey = null, Dictionary<string, string> propertyFilter = null);
 
     string CreateFeature(string collectionId, IFeature feature, string apiKey = null);
 

--- a/OgcApi.Net/DataProviders/SqlDataProvider.cs
+++ b/OgcApi.Net/DataProviders/SqlDataProvider.cs
@@ -240,7 +240,8 @@ public abstract class SqlDataProvider(ILogger logger, IOptionsMonitor<OgcApiOpti
         Envelope bbox = null,
         DateTime? startDateTime = null,
         DateTime? endDateTime = null,
-        string apiKey = null)
+        string apiKey = null,
+        Dictionary<string, string> propertyFilter = null)
     {
         var collectionOptions = (CollectionOptions)CollectionsOptions.GetSourceById(collectionId);
         if (collectionOptions == null)
@@ -270,6 +271,7 @@ public abstract class SqlDataProvider(ILogger logger, IOptionsMonitor<OgcApiOpti
                 .AddWhere(bbox)
                 .AddWhere(startDateTime, endDateTime)
                 .AddApiKeyWhere(sourceOptions.ApiKeyPredicateForGet, apiKey)
+                .AddWhere(propertyFilter)
                 .ComposeWhereClause()
                 .BuildCommand(connection);
 

--- a/OgcApi.Net/Features/OgcFeatureCollectionConverter.cs
+++ b/OgcApi.Net/Features/OgcFeatureCollectionConverter.cs
@@ -17,8 +17,8 @@ public class OgcFeatureCollectionConverter : JsonConverter<OgcFeatureCollection>
         writer.WriteString("type", "FeatureCollection");
 
         writer.WriteString("timeStamp", DateTime.Now);
-        writer.WriteString("numberMatched", value.TotalMatched.ToString());
-        writer.WriteString("numberReturned", value.Count.ToString());
+        writer.WriteNumber("numberMatched", value.TotalMatched);
+        writer.WriteNumber("numberReturned", value.Count);
 
         if (value.Links != null)
         {


### PR DESCRIPTION
`ogc/collections/{collectionId}/items` returns an incorrect value in `numberMatched` field when using simple attribute filters
![image](https://github.com/user-attachments/assets/67a43b3e-b942-4ed0-9ee1-da2a2cea5f52)
This is because the `propertyFilter` dictionary is not taken into account in `IFeaturesProvider.GetFeaturesCount`.
