### PR TITLE
Make calculating numberMatched optional for feature collection queries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ This implementation supports automatic API generation from metadata descriptions
 
 This implementation uses attribute routing. All API endpoints will be accessible via the `/api/ogc` path.
 
-API configuration can be done using a configuration file named `ogcsettings.json`, which has the following structure:
+API configuration can be done using a configuration file named `ogcapi.json` or `ogcsettings.json`, which has the following structure:
 
 ### Options example
 
@@ -96,6 +96,11 @@ In the landing page options, you must specify:
 - **ApiDocumentPage** - URL to the API definition (Swagger or custom HTML page with API description)
 - **ApiDescriptionPage** - URL to the API documentation (OpenAPI JSON)
 
+In the landing page options, you can optionally specify:
+- **LicenseName** - Name of the license
+- **LicenseUrl** - URL to the license definition
+- **Links** - A list of other links
+
 In collection options, you must specify:
 - **Id** - unique identifier of the collection
 - **Title**
@@ -108,3 +113,10 @@ Collection can be:
 - hybrid: features + tiles. That means that API consumer can use tiles API for fast data queries and features API to get precise objects coordinates or modify objects
 
 Tiles and features providers for one collection can be different. For example, you can create collection that publishes features from the database, but the tiles can be taken from mbtiles file.
+
+In collection options, you can optionally specify:
+- **Description**
+- **Links** - a list of other links
+- **Extent** - the spatial and/or temporal extent of the collection
+- **ItemType** - indicator of the type of items in the collection, defaults to `feature`
+- **CalculateNumberMatched** - a boolean flag indicating if the number of matched items by a query should be returned in the response. It is recommended to set to `false` for large tables. Defaults to `true`

--- a/src/Common/OgcApi.Net/Controllers/CollectionsController.cs
+++ b/src/Common/OgcApi.Net/Controllers/CollectionsController.cs
@@ -294,7 +294,7 @@ public class CollectionsController : ControllerBase
 
                 var features = dataProvider.GetFeatures(
                     collectionOptions.Id,
-                    limit + 1,
+                    limit + 1,  // Retrieve one more feature to see if there is a next page
                     offset,
                     envelope,
                     dateTimeInterval.Start,
@@ -302,7 +302,7 @@ public class CollectionsController : ControllerBase
                     apiKey,
                     propertyFilter);
                 
-                bool nextPageExists = features.Count > limit;
+                var nextPageExists = features.Count > limit;
                 
                 if (nextPageExists)
                 {

--- a/src/Common/OgcApi.Net/Controllers/CollectionsController.cs
+++ b/src/Common/OgcApi.Net/Controllers/CollectionsController.cs
@@ -286,21 +286,29 @@ public class CollectionsController : ControllerBase
             try
             {
                 Dictionary<string, string> propertyFilter = null;
-		        if (properties is {Count: > 0})
-		        {
-			        propertyFilter = Request.Query.Keys.Where(properties.Contains)
-				        .ToDictionary(key => key, key => Request.Query[key].First());
-		        }
+                if (properties is {Count: > 0})
+                {
+                    propertyFilter = Request.Query.Keys.Where(properties.Contains)
+                        .ToDictionary(key => key, key => Request.Query[key].First());
+                }
 
                 var features = dataProvider.GetFeatures(
                     collectionOptions.Id,
-                    limit,
+                    limit + 1,
                     offset,
                     envelope,
                     dateTimeInterval.Start,
                     dateTimeInterval.End,
                     apiKey,
                     propertyFilter);
+                
+                bool nextPageExists = features.Count > limit;
+                
+                if (nextPageExists)
+                {
+                    features.RemoveAt(limit);
+                }
+                
                 features.Transform(collectionOptions.Features.StorageCrs, crs);
 
                 features.Links =
@@ -321,15 +329,7 @@ public class CollectionsController : ControllerBase
                     }
                 ];
 
-                features.TotalMatched = dataProvider.GetFeaturesCount(
-                    collectionOptions.Id,
-                    envelope,
-                    dateTimeInterval.Start,
-                    dateTimeInterval.End,
-                    apiKey,
-                    propertyFilter);
-
-                if (offset + limit < features.TotalMatched)
+                if (nextPageExists)
                 {
                     var parameters = HttpUtility.ParseQueryString(Request.QueryString.ToString());
                     parameters.Set("offset", (offset + limit).ToString());
@@ -340,6 +340,21 @@ public class CollectionsController : ControllerBase
                         Rel = "next",
                         Type = "application/geo+json"
                     });
+                }
+
+                if (collectionOptions.CalculateNumberMatched)
+                {
+                    features.TotalMatched = dataProvider.GetFeaturesCount(
+                        collectionOptions.Id,
+                        envelope,
+                        dateTimeInterval.Start,
+                        dateTimeInterval.End,
+                        apiKey,
+                        propertyFilter);
+                }
+                else
+                {
+                    features.TotalMatched = null;
                 }
 
                 Response.Headers.Append("Content-Crs", $"<{crs}>");

--- a/src/Common/OgcApi.Net/Features/OgcFeatureCollection.cs
+++ b/src/Common/OgcApi.Net/Features/OgcFeatureCollection.cs
@@ -9,5 +9,5 @@ public class OgcFeatureCollection() : Collection<IFeature>(new List<IFeature>())
 {
     public List<Link> Links { get; set; }
 
-    public long TotalMatched { get; set; }
+    public long? TotalMatched { get; set; }
 }

--- a/src/Common/OgcApi.Net/Features/OgcFeatureCollectionConverter.cs
+++ b/src/Common/OgcApi.Net/Features/OgcFeatureCollectionConverter.cs
@@ -17,7 +17,10 @@ public class OgcFeatureCollectionConverter : JsonConverter<OgcFeatureCollection>
         writer.WriteString("type", "FeatureCollection");
 
         writer.WriteString("timeStamp", DateTime.Now);
-        writer.WriteNumber("numberMatched", value.TotalMatched);
+        if (value.TotalMatched.HasValue)
+        {
+            writer.WriteNumber("numberMatched", (long)value.TotalMatched);
+        }
         writer.WriteNumber("numberReturned", value.Count);
 
         if (value.Links != null)

--- a/src/Common/OgcApi.Net/Options/CollectionOptions.cs
+++ b/src/Common/OgcApi.Net/Options/CollectionOptions.cs
@@ -47,7 +47,7 @@ public class CollectionOptions : ICollectionOptions
     /// <summary>
     /// An optional indicator that specifies whether the number of items in the collection should be calculated (true) or not (false).
     /// </summary>
-    [JsonIgnore(Condition =JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool CalculateNumberMatched { get; set; } = true;
 
     public Func<string, Uri> FeatureHtmlPage { get; set; }

--- a/src/Common/OgcApi.Net/Options/CollectionOptions.cs
+++ b/src/Common/OgcApi.Net/Options/CollectionOptions.cs
@@ -44,6 +44,12 @@ public class CollectionOptions : ICollectionOptions
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string ItemType { get; set; }
 
+    /// <summary>
+    /// An optional indicator that specifies whether the number of items in the collection should be calculated (true) or not (false).
+    /// </summary>
+    [JsonIgnore(Condition =JsonIgnoreCondition.WhenWritingDefault)]
+    public bool CalculateNumberMatched { get; set; } = true;
+
     public Func<string, Uri> FeatureHtmlPage { get; set; }
 
     public CollectionFeaturesOptions Features { get; set; }

--- a/src/Common/OgcApi.Net/Resources/Collection.cs
+++ b/src/Common/OgcApi.Net/Resources/Collection.cs
@@ -19,6 +19,9 @@ public class Collection
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string ItemType { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool CalculateNumberMatched { get; set; } = true;
+
     public List<Uri> Crs { get; set; }
 
     public Uri StorageCrs { get; set; }

--- a/tests/OgcApi.Net.Options.Tests/ConfigurationDeserializationFacts.cs
+++ b/tests/OgcApi.Net.Options.Tests/ConfigurationDeserializationFacts.cs
@@ -77,6 +77,7 @@ public class ConfigurationDeserializationFacts(ConfigurationOptionsFixture fixtu
         Assert.Equal("Collection title 1", fixture.Options.Collections.Items[0].Title);
         Assert.Equal("Collection description 1", fixture.Options.Collections.Items[0].Description);
         Assert.Equal("Collection1 ItemType", fixture.Options.Collections.Items[0].ItemType);
+        Assert.False(fixture.Options.Collections.Items[0].CalculateNumberMatched);
         Assert.NotNull(fixture.Options.Collections.Items[0].Features);
     }
 
@@ -88,6 +89,7 @@ public class ConfigurationDeserializationFacts(ConfigurationOptionsFixture fixtu
         Assert.Equal("Collection title 2", fixture.Options.Collections.Items[1].Title);
         Assert.Equal("Collection description 2", fixture.Options.Collections.Items[1].Description);
         Assert.Equal("Collection2 ItemType", fixture.Options.Collections.Items[1].ItemType);
+        Assert.True(fixture.Options.Collections.Items[1].CalculateNumberMatched);
         Assert.NotNull(fixture.Options.Collections.Items[1].Features);
     }
 

--- a/tests/OgcApi.Net.Options.Tests/JsonDeserializationFacts.cs
+++ b/tests/OgcApi.Net.Options.Tests/JsonDeserializationFacts.cs
@@ -76,6 +76,7 @@ public class JsonDeserializationFacts(ConfigurationOptionsFixture fixture) : ICl
         Assert.Equal("Collection title 1", fixture.Options.Collections.Items[0].Title);
         Assert.Equal("Collection description 1", fixture.Options.Collections.Items[0].Description);
         Assert.Equal("Collection1 ItemType", fixture.Options.Collections.Items[0].ItemType);
+        Assert.False(fixture.Options.Collections.Items[0].CalculateNumberMatched);
         Assert.NotNull(fixture.Options.Collections.Items[0].Features);
     }
 
@@ -87,6 +88,7 @@ public class JsonDeserializationFacts(ConfigurationOptionsFixture fixture) : ICl
         Assert.Equal("Collection title 2", fixture.Options.Collections.Items[1].Title);
         Assert.Equal("Collection description 2", fixture.Options.Collections.Items[1].Description);
         Assert.Equal("Collection2 ItemType", fixture.Options.Collections.Items[1].ItemType);
+        Assert.True(fixture.Options.Collections.Items[1].CalculateNumberMatched);
         Assert.NotNull(fixture.Options.Collections.Items[1].Features);
     }
 

--- a/tests/OgcApi.Net.Options.Tests/ogcsettings.json
+++ b/tests/OgcApi.Net.Options.Tests/ogcsettings.json
@@ -40,6 +40,7 @@
         "Title": "Collection title 1",
         "Description": "Collection description 1",
         "ItemType": "Collection1 ItemType",
+        "CalculateNumberMatched": false,
         "Extent": {
           "Spatial": {
             "Bbox": [


### PR DESCRIPTION
Hi Everyone,

This PR aims to make the `numberMatched` value in a returned feature set optional. This is important because the current way of calculating it is based on a count of all rows in the database query result. This is fine for relatively small tables, but gets prohibitively expensive for large ones. As I am using this project to expose features from tables of tens of millions of records, calculating the `numberMatched` value causes API query execution time to balloon and result in a timeout.

In the [OGC API Standard Section 7.1](https://docs.ogc.org/is/17-069r4/17-069r4.html#core-overview) the following is stated on `numberMatched` and `numberReturned`:

```
Each page may include information about the number of selected and returned features (numberMatched and numberReturned) as well as links to support paging (link relation next).
```

This means that these two numbers can optionally be included in the returned GeoJSON object. The current implementation of OgcApi.Net automatically calculates these, though, resulting in problems with large files.

My modifications in this PR implement an additional configuration option called `CalculateNumberMatched` for each feature collection item. It defaults to `true` so as not to break existing functionality, and if set to false, it skips the calculation of the `numberMatched` property in `CollectionsController`'s `GetItems` method. To still handle pagination links properly, I have implemented a way where the `CollectionsController` tries to fetch one more record than the user-defined limit, and if it exists, it will include a link to the next page, while only returning the number of rows requested by the user. This adds the overhead of fetching plus one row in the queries, but it does away with the expensive count. An additional caveat for tables where `CalculateNumberMatched` is set to `false` is that there will be no `numberMatched` in the response so the client will have no knowledge of the esitmated number of pages to expect.

Overall, I think this tradeoff is worth it as it still preserves `numberMatched` for most tables, but enables the usage of the service for large tables which produced timeouts until now.

I am interested in your feedback and if you can accept my modifications. Also generally excited to be contributing to such an interesting open-source project.