### PR TITLE
Downgrade Microsoft.OpenApi to 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ For more details about installation and configuration, see the [Installation Gui
 
 For a full setup guide, refer to the [API Configuration Documentation](https://sam-is.github.io/OgcApi.Net/configuration).
 
+### Compatibility Notice with Microsoft.AspNetCore.OpenApi
+
+There is a [known incompatibility](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-3.md#integrations-with-aspnet-core) between `Microsoft.OpenApi` version 3+ and `Microsoft.AspNetCore.OpenApi` version 10+. Please choose the package version carefully:
+
+| Package Version | Microsoft.OpenApi Dependency | Compatibility |
+| :--- | :--- | :--- |
+| **3.0.0** (Recommended) | 2.7.0 | Compatible with **Microsoft.AspNetCore.OpenApi 10+** |
+| **2.0.0** | 3.3.1 | Incompatible with Microsoft.AspNetCore.OpenApi 10+ |
+
+ If you are using **Microsoft.AspNetCore.OpenApi 10+**, please use package version **3.0.0**.
+
 ## Contributing
 
 We welcome contributions from the community! Whether you're fixing bugs, improving documentation, or adding new features, your help is greatly appreciated.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,9 +25,25 @@ This project uses:
 - [ProjNET](https://github.com/NetTopologySuite/ProjNet4GeoAPI ) for coordinate transformations
 - [OpenAPI.NET](https://github.com/Microsoft/OpenAPI.NET ) for OpenAPI document generation
 
+## OpenAPI.NET version
+
 OpenAPI.NET v3.3.1 contains [breaking changes](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-2.md) compared to v1.6. If your project uses OpenAPI.NET < 2.0.0, you must either:
 - Upgrade to OpenAPI.NET ≥ 2.0.0, or
 - Use OgcApi.Net v1.2.2 (which depends on OpenAPI.NET 1.6.14)
+
+### **Compatibility with Microsoft.AspNetCore.OpenApi v10+**
+
+`OpenAPI.NET` v3.3.1 is [not compatible](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-3.md#integrations-with-aspnet-core) with `Microsoft.AspNetCore.OpenApi` v10+.
+
+If your application uses `Microsoft.AspNetCore.OpenApi`, please use **OgcApi.Net v3.0.0**. This version depends on `OpenAPI.NET` v2.7.0, which maintains compatibility with `Microsoft.AspNetCore.OpenApi` v10+.
+
+### Version Compatibility
+
+| OgcApi.Net Version | OpenAPI.NET Dependency | Notes |
+| :--- | :--- | :--- |
+| **1.2.2** | 1.6.14 | Legacy version |
+| **2.0.0** | 3.3.1 | Not compatible with `Microsoft.AspNetCore.OpenApi` v10+ |
+| **3.0.0** | 2.7.0 | Compatible with `Microsoft.AspNetCore.OpenApi` v10+ |
 
 The source code targets .NET 8 and .NET 10.
 

--- a/src/Common/OgcApi.Net/OgcApi.Net.csproj
+++ b/src/Common/OgcApi.Net/OgcApi.Net.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.OpenApi" Version="3.3.1" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
     <PackageReference Include="NetTopologySuite.IO.VectorTiles.Mapbox" Version="1.1.0" />
     <PackageReference Include="ProjNet" Version="2.1.0" />

--- a/src/Common/OgcApi.Net/OpenApi/OpenApiGenerator.cs
+++ b/src/Common/OgcApi.Net/OpenApi/OpenApiGenerator.cs
@@ -56,7 +56,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "Success",
-                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    Content = new Dictionary<string, OpenApiMediaType>
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -98,7 +98,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "Success",
-                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    Content = new Dictionary<string, OpenApiMediaType>
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -138,7 +138,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "Success",
-                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    Content = new Dictionary<string, OpenApiMediaType>
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -452,7 +452,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "Success",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -463,7 +463,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                             ["404"] = new OpenApiResponse
                             {
                                 Description = "Not Found",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -507,7 +507,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "Success",
-                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    Content = new Dictionary<string, OpenApiMediaType>
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -522,7 +522,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                                 ["404"] = new OpenApiResponse
                                 {
                                     Description = "Not Found",
-                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    Content = new Dictionary<string, OpenApiMediaType>
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -590,7 +590,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "Success",
-                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    Content = new Dictionary<string, OpenApiMediaType>
                                     {
                                         ["application/vnd.mapbox-vector-tile"] = new OpenApiMediaType
                                         {
@@ -605,7 +605,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                                 ["404"] = new OpenApiResponse
                                 {
                                     Description = "Not Found",
-                                    Content = new Dictionary<string, IOpenApiMediaType>
+                                    Content = new Dictionary<string, OpenApiMediaType>
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -970,7 +970,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["200"] = new OpenApiResponse
                     {
                         Description = "Success",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/geo+json"] = new OpenApiMediaType
                             {
@@ -981,7 +981,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["400"] = new OpenApiResponse
                     {
                         Description = "Bad Request",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -992,7 +992,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["404"] = new OpenApiResponse
                     {
                         Description = "Not Found",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1038,7 +1038,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                 ],
                 RequestBody = new OpenApiRequestBody
                 {
-                    Content = new Dictionary<string, IOpenApiMediaType>
+                    Content = new Dictionary<string, OpenApiMediaType>
                     {
                         ["application/geo+json"] = new OpenApiMediaType
                         {
@@ -1055,7 +1055,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["400"] = new OpenApiResponse
                     {
                         Description = "Bad Request",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1066,7 +1066,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["401"] = new OpenApiResponse
                     {
                         Description = "Unauthorized",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1077,7 +1077,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["404"] = new OpenApiResponse
                     {
                         Description = "Not Found",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1119,7 +1119,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["400"] = new OpenApiResponse
                     {
                         Description = "Bad Request",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1130,7 +1130,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["401"] = new OpenApiResponse
                     {
                         Description = "Unauthorized",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1141,7 +1141,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["404"] = new OpenApiResponse
                     {
                         Description = "Not Found",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1187,7 +1187,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                 ],
                 RequestBody = new OpenApiRequestBody
                 {
-                    Content = new Dictionary<string, IOpenApiMediaType>
+                    Content = new Dictionary<string, OpenApiMediaType>
                     {
                         ["application/geo+json"] = new OpenApiMediaType
                         {
@@ -1204,7 +1204,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["400"] = new OpenApiResponse
                     {
                         Description = "Bad Request",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1215,7 +1215,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["401"] = new OpenApiResponse
                     {
                         Description = "Unauthorized",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1226,7 +1226,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["404"] = new OpenApiResponse
                     {
                         Description = "Not Found",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1373,7 +1373,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["200"] = new OpenApiResponse
                     {
                         Description = "Success",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/geo+json"] = new OpenApiMediaType
                             {
@@ -1384,7 +1384,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["400"] = new OpenApiResponse
                     {
                         Description = "Bad Request",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1395,7 +1395,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["404"] = new OpenApiResponse
                     {
                         Description = "Not Found",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1433,7 +1433,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                 ],
                 RequestBody = new OpenApiRequestBody
                 {
-                    Content = new Dictionary<string, IOpenApiMediaType>
+                    Content = new Dictionary<string, OpenApiMediaType>
                     {
                         ["application/geo+json"] = new OpenApiMediaType
                         {
@@ -1454,7 +1454,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["400"] = new OpenApiResponse
                     {
                         Description = "Bad Request",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1465,7 +1465,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["401"] = new OpenApiResponse
                     {
                         Description = "Unauthorized",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {
@@ -1476,7 +1476,7 @@ public class OpenApiGenerator(IOptionsMonitor<OgcApiOptions> apiOptions, IEnumer
                     ["404"] = new OpenApiResponse
                     {
                         Description = "Not Found",
-                        Content = new Dictionary<string, IOpenApiMediaType>
+                        Content = new Dictionary<string, OpenApiMediaType>
                         {
                             ["application/json"] = new OpenApiMediaType
                             {

--- a/src/Common/OgcApi.Net/Utils.cs
+++ b/src/Common/OgcApi.Net/Utils.cs
@@ -70,7 +70,6 @@ public static class Utils
         "2.0" => OpenApiSpecVersion.OpenApi2_0,
         "3.0" => OpenApiSpecVersion.OpenApi3_0,
         "3.1" => OpenApiSpecVersion.OpenApi3_1,
-        "3.2" => OpenApiSpecVersion.OpenApi3_2,
-        _ => throw new NotImplementedException($"OpenApi version {version} is not valid. Valid version values are: 2.0, 3.0, 3.1, 3.2")
+        _ => throw new NotImplementedException($"OpenApi version {version} is not valid. Valid version values are: 2.0, 3.0, 3.1")
     };
 }

--- a/src/Common/Standards/OgcApi.Net.Schemas/SchemasOpenApiExtension.cs
+++ b/src/Common/Standards/OgcApi.Net.Schemas/SchemasOpenApiExtension.cs
@@ -119,7 +119,7 @@ public class SchemasOpenApiExtension : IOpenApiExtension
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "Success",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -130,7 +130,7 @@ public class SchemasOpenApiExtension : IOpenApiExtension
                             ["404"] = new OpenApiResponse
                             {
                                 Description = "Not Found",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -160,7 +160,7 @@ public class SchemasOpenApiExtension : IOpenApiExtension
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "Success",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -171,7 +171,7 @@ public class SchemasOpenApiExtension : IOpenApiExtension
                             ["404"] = new OpenApiResponse
                             {
                                 Description = "Not Found",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -201,7 +201,7 @@ public class SchemasOpenApiExtension : IOpenApiExtension
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "Success",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -212,7 +212,7 @@ public class SchemasOpenApiExtension : IOpenApiExtension
                             ["404"] = new OpenApiResponse
                             {
                                 Description = "Not Found",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {

--- a/src/Common/Standards/OgcApi.Net.Styles/Extensions/StylesOpenApiExtension.cs
+++ b/src/Common/Standards/OgcApi.Net.Styles/Extensions/StylesOpenApiExtension.cs
@@ -185,7 +185,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "Success",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -209,7 +209,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                         Description = "Adds a new style to the styles storage if style does not exist.",
                         RequestBody = new OpenApiRequestBody
                         {
-                            Content = new Dictionary<string, IOpenApiMediaType>
+                            Content = new Dictionary<string, OpenApiMediaType>
                             {
                                 ["application/json"] = new OpenApiMediaType
                                 {
@@ -242,7 +242,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                         Summary = "Updates default style of the collection",
                         RequestBody = new OpenApiRequestBody
                         {
-                            Content = new Dictionary<string, IOpenApiMediaType>
+                            Content = new Dictionary<string, OpenApiMediaType>
                             {
                                 ["application/merge-patch+json"] = new OpenApiMediaType
                                 {
@@ -307,7 +307,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "Success",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -334,7 +334,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                         Summary = "Replaces existing stylesheet",
                         RequestBody = new OpenApiRequestBody
                         {
-                            Content = new Dictionary<string, IOpenApiMediaType>
+                            Content = new Dictionary<string, OpenApiMediaType>
                             {
                                 ["application/json"] = new OpenApiMediaType
                                 {
@@ -429,7 +429,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "Success",
-                                Content = new Dictionary<string, IOpenApiMediaType>
+                                Content = new Dictionary<string, OpenApiMediaType>
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -466,7 +466,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                         ],
                         RequestBody = new OpenApiRequestBody
                         {
-                            Content = new Dictionary<string, IOpenApiMediaType>
+                            Content = new Dictionary<string, OpenApiMediaType>
                             {
                                 ["application/json"] = new OpenApiMediaType
                                 {
@@ -509,7 +509,7 @@ public class StylesOpenApiExtension : IOpenApiExtension
                         ],
                         RequestBody = new OpenApiRequestBody
                         {
-                            Content = new Dictionary<string, IOpenApiMediaType>
+                            Content = new Dictionary<string, OpenApiMediaType>
                             {
                                 ["application/merge-patch+json"] = new OpenApiMediaType
                                 {

--- a/tests/OgcApi.Net.Options.Tests/OpenApiVersionTests.cs
+++ b/tests/OgcApi.Net.Options.Tests/OpenApiVersionTests.cs
@@ -18,7 +18,6 @@ public class OpenApiVersionTests
     [InlineData("2.0", OpenApiSpecVersion.OpenApi2_0)]
     [InlineData("3.0", OpenApiSpecVersion.OpenApi3_0)]
     [InlineData("3.1", OpenApiSpecVersion.OpenApi3_1)]
-    [InlineData("3.2", OpenApiSpecVersion.OpenApi3_2)]
     public void MappingValidOpenApiVersion(string version, OpenApiSpecVersion expectedVersion)
     {
         var openApiVersion = Net.Utils.GetOpenApiSpecVersion(version);


### PR DESCRIPTION
## Description
Downgrade `Microsoft.OpenApi` dependency from v3.3.1 to v2.7.0 to fix compatibility with `Microsoft.AspNetCore.OpenApi` v10+.

In the future, compatibility may be restored, and we will need to upgrade `Microsoft.OpenApi` to a version compatible with the latest `Microsoft.AspNetCore.OpenApi`.

## Reason
`Microsoft.OpenApi` v3.3.1 contains breaking changes that are currently incompatible with `Microsoft.AspNetCore.OpenApi` v10+ ([see upgrade guide](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-3.md#integrations-with-aspnet-core)). 

This change ensures that `OgcApi.Net` works correctly in projects with Microsoft.AspNetCore.OpenApi.

## Dependency Versions

Given the breaking changes introduced, the next release should be version 3.0.0. Taking this into account, the Microsoft.OpenApi version dependency will look like this:

| OgcApi.Net Version | Microsoft.OpenApi Dependency | Compatible with ASP.NET Core 10+ |
| :--- | :--- | :--- |
| 1.2.2 | 1.6.14 |  |
| 2.0.0 | 3.3.1 |  No |
| **3.0.0** | **2.7.0** |  Yes |

## Changes
- Updated `Microsoft.OpenApi` package reference to v2.7.0 in `.csproj`
- Changed `IOpenApiMediaType` interface to `OpenApiMediaType` class
- Updated `README.md` and `Owerview` in docs with compatibility notice and version table